### PR TITLE
Clean up the configured nvramRestartCmd

### DIFF
--- a/mythtv/programs/mythshutdown/main.cpp
+++ b/mythtv/programs/mythshutdown/main.cpp
@@ -650,7 +650,7 @@ static int shutdown()
 
     int shutdownmode = 0; // default to poweroff no reboot
     QString nvramRestartCmd =
-            gCoreContext->GetSetting("MythShutdownNvramRestartCmd", "");
+            gCoreContext->GetSetting("MythShutdownNvramRestartCmd", "").trimmed();
 
     if (dtWakeupTime.isValid())
     {


### PR DESCRIPTION
Hi, please include this patch for
https://code.mythtv.org/trac/ticket/12770

Avoid going to shutdownmode = 1 just because of spurious white space in nvramRestartCmd